### PR TITLE
jQuery load robustness + allow event label modification

### DIFF
--- a/vimeo.ga.js
+++ b/vimeo.ga.js
@@ -120,7 +120,9 @@ var vimeoGAJS = {};
   getLabel : function(iframeEl) {
     var iframeSrc = iframeEl.attr('src').split('?')[0];
     var label = vimeoGAJS.getUrl(iframeSrc);
-    if (iframeEl.attr('title')) {
+    if (iframeEl.data('title')) {
+      label += ' (' + iframeEl.data('title') + ')';
+    } else if (iframeEl.attr('title')) {
       label += ' (' + iframeEl.attr('title') + ')';
     }
     return label;

--- a/vimeo.ga.js
+++ b/vimeo.ga.js
@@ -6,7 +6,8 @@
  */
 
 
-var vimeoGAJS = {
+var vimeoGAJS = {};
+(function($){vimeoGAJS={
   iframes : [],
   gaTracker : undefined,
   eventMarker : {},
@@ -116,6 +117,15 @@ var vimeoGAJS = {
     return iframeSrc;
   },
 
+  getLabel : function(iframeEl) {
+    var iframeSrc = iframeEl.attr('src').split('?')[0];
+    var label = vimeoGAJS.getUrl(iframeSrc);
+    if (iframeEl.attr('title')) {
+      label += ' (' + iframeEl.attr('title') + ')';
+    }
+    return label;
+  },
+
   // Helper function for sending a message to the player
   post : function (action, value, iframe) {
     var data = {
@@ -182,25 +192,23 @@ var vimeoGAJS = {
 
   // Send event to Classic Analytics, Universal Analytics or Google Tag Manager
   sendEvent: function (iframeEl, action) {
-    var iframeSrc = iframeEl.attr('src').split('?')[0];
     var bounce = iframeEl.data('bounce');
+    var label = vimeoGAJS.getLabel(iframeEl);
 
     switch (vimeoGAJS.gaTracker) {
     case 'gtm':
-      dataLayer.push({'event': 'Vimeo', 'eventCategory': 'Vimeo', 'eventAction': action, 'eventLabel': vimeoGAJS.getUrl(iframeSrc), 'eventValue': undefined, 'eventNonInteraction': (bounce) ? false : true });
+      dataLayer.push({'event': 'Vimeo', 'eventCategory': 'Vimeo', 'eventAction': action, 'eventLabel': label, 'eventValue': undefined, 'eventNonInteraction': (bounce) ? false : true });
       break;
 
     case 'ua':
-      ga('send', 'event', 'Vimeo', action, vimeoGAJS.getUrl(iframeSrc), undefined, {'nonInteraction': (bounce) ? 0 : 1});
+      ga('send', 'event', 'Vimeo', action, label, undefined, {'nonInteraction': (bounce) ? 0 : 1});
       break;
 
     case 'ga':
-      _gaq.push(['_trackEvent', 'Vimeo', action, vimeoGAJS.getUrl(iframeSrc), undefined, (bounce) ? false : true]);
+      _gaq.push(['_trackEvent', 'Vimeo', action, label, undefined, (bounce) ? false : true]);
       break;
     }
   }
 };
-
-$(function() {
-  vimeoGAJS.init();
-});
+vimeoGAJS.init();
+})(jQuery);


### PR DESCRIPTION
Hi

I've committed a change in my fork of vimeo.ga.js which:

 * Makes the code load a bit cleaner if jQuery is taking it's time to load
 * Allows a title to be appended to the event label based on the title attribute of the video iframe. This can make the analytics a bit easier to read.

Cheers
Vittal