### PR TITLE
Add support for protocol relative URLs and set them to https

### DIFF
--- a/vimeo.ga.js
+++ b/vimeo.ga.js
@@ -130,6 +130,10 @@ var vimeoGAJS = (window.vimeoGAJS) ? window.vimeoGAJS : {};
 
       // Source URL
       var iframeSrc = $(iframe).attr('src').split('?')[0];
+      // Set to https if protocol relative URL is used
+      if(iframeSrc.substring(0,2) === "//") {
+          iframeSrc = "https:"+iframeSrc;
+      }
 
       iframe.contentWindow.postMessage(JSON.stringify(data), iframeSrc);
     },


### PR DESCRIPTION
Hi, I'm using this with Drupal site where the embedded videos are generated with protocol relative URLs. It wasn't tracking for me with a protocol relative URL. What do you think of this modification?