### PR TITLE
vimeo-video class enhancement

### DIFF
--- a/vimeo.ga.js
+++ b/vimeo.ga.js
@@ -15,7 +15,7 @@ var vimeoGAJS = (window.vimeoGAJS) ? window.vimeoGAJS : {};
     eventMarker : {},
 
     init: function () {
-      vimeoGAJS.iframes = $('iframe');
+      vimeoGAJS.iframes = $('iframe.vimeo-video');
 
       $.each(vimeoGAJS.iframes, function (index, iframe) {
         var iframeId = $(iframe).attr('id');


### PR DESCRIPTION
In current functionality, this tracking script run on all iframes of a webpage.That's why if iframe has no Vimeo video it starts breaking the tracking functionality.
I added **"vimeo-video"** class with iframe selector.